### PR TITLE
Fixes Implicit conversion

### DIFF
--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -127,7 +127,7 @@ class LineChart extends Chart
 
 
         for ($i = 1; $i < $this->valueGroups; $i++) {
-            $y = $this->height * .9 - $this->margin - ($i / $this->valueGroups) * ($this->height * .9 - 2 * $this->margin);
+            $y = strval($this->height * .9 - $this->margin - ($i / $this->valueGroups) * ($this->height * .9 - 2 * $this->margin));
             $res['values'][$y] = $this->min + $i * ($this->max - $this->min) / $this->valueGroups;
 
             if (isset($this->options['valueFormatter'])) {


### PR DESCRIPTION
Hey @dpodsiadlo 

I'm sending this pull request to fix a warning about the loses precision when you draw the grid.

`Implicit conversion from float 20.4 to int loses precision in /var/www/html/vendor/dpodsiadlo/svg-charts/src/Charts/LineChart.php on line 133`

Thanks.